### PR TITLE
Remove "module" from "content" attribute in config/default.json

### DIFF
--- a/generators/app/templates/config/default.json
+++ b/generators/app/templates/config/default.json
@@ -14,9 +14,7 @@
       "options": {
         "paths": {
           "/{args*}": {
-            "content": {
-              "module": "./server/views/index-view"
-            }
+            "content": "./server/views/index-view"
           }
         }
       }


### PR DESCRIPTION
Hi,

Thanks for all your great work! I am looking forward to learning a Electrode.

Today I was following the "Get Started" (http://www.electrode.io/docs/get_started.html) tutorial, and was having issues. The biggest was that it would work locally, but not deploy to Heroku. It would say "Electrode Server register plugins timeout.  Did you forget next() in a plugin?" when trying to start the server, though the server worked locally. On Heroku, the app would crash.

I looked at all kinds of things, but it appears that having the properties nested was causing errors when deploying to Heroku. Deleting the "module" attribute fixed the issue, and the app no longer crashes.

I was confused because all I did before attempting to deploy to was basically `yo electrode`, and paste some code. I imagine that others are having the same confusion.

After much investigation, I was able to figure it out by looking at: https://github.com/electrode-io/electrode-react-webapp. The README there does not specify a "module". https://github.com/electrode-io/electrode-react-webapp#content-details, and that was the hint I needed.

I am sharing this to hopefully save someone else the frustration I had.

Thanks again for all your work.

Cheers,
Ezra.