### PR TITLE
Disable installing the bower dependencies in the app generator

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -286,6 +286,8 @@ module.exports = generators.Base.extend({
   },
 
   install: function () {
-    this.installDependencies();
+    this.installDependencies({
+      bower: false
+    });
   }
 });


### PR DESCRIPTION
While generating a new app with this generator it will try and install the bower dependencies that are not available:

> Running npm install && bower install for you to install the required dependencies.

Resulting in this error:

> bower ENOENT No bower.json present

This PR fixes that by disabling the bower installation.