### PR TITLE
Add engines in package.json to match electrode-archetype-react-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,9 @@
     "prepublish": "gulp prepublish",
     "test": "gulp"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "engines": {
+    "node": "^4.4.6 || ^6.2.1",
+    "npm": "^3.5.3"
+  }
 }


### PR DESCRIPTION
Related to electrode-io/electrode-archetype-react-app#29

I've never used Yeoman, I'm not sure my change will change the generated file but I couldn't find a `package.json` in the `generators` folder.