### PR TITLE
create new directory for app, generateInto clean up

### DIFF
--- a/generators/config/index.js
+++ b/generators/config/index.js
@@ -6,13 +6,6 @@ module.exports = generators.Base.extend({
   constructor: function () {
     generators.Base.apply(this, arguments);
 
-    this.option('generateInto', {
-      type: String,
-      required: false,
-      defaults: '',
-      desc: 'Relocate the location of the generated files.'
-    });
-
     this.option('name', {
       type: String,
       required: true,
@@ -23,7 +16,7 @@ module.exports = generators.Base.extend({
   writing: function () {
     this.fs.copyTpl(
       this.templatePath('default.json'),
-      this.destinationPath(this.options.generateInto, 'config/default.json'),
+      this.destinationPath('config/default.json'),
       {
         projectName: this.options.name
       }

--- a/generators/editorconfig/index.js
+++ b/generators/editorconfig/index.js
@@ -4,19 +4,12 @@ var generators = require('yeoman-generator');
 module.exports = generators.Base.extend({
   constructor: function () {
     generators.Base.apply(this, arguments);
-
-    this.option('generateInto', {
-      type: String,
-      required: false,
-      defaults: '',
-      desc: 'Relocate the location of the generated files.'
-    });
   },
 
   initializing: function () {
     this.fs.copy(
       this.templatePath('editorconfig'),
-      this.destinationPath(this.options.generateInto, '.editorconfig')
+      this.destinationPath('.editorconfig')
     );
   }
 });

--- a/generators/git/index.js
+++ b/generators/git/index.js
@@ -6,13 +6,6 @@ module.exports = generators.Base.extend({
   constructor: function () {
     generators.Base.apply(this, arguments);
 
-    this.option('generateInto', {
-      type: String,
-      required: false,
-      defaults: '',
-      desc: 'Relocate the location of the generated files.'
-    });
-
     this.option('name', {
       type: String,
       required: true,
@@ -29,15 +22,15 @@ module.exports = generators.Base.extend({
   initializing: function () {
     this.fs.copy(
       this.templatePath('gitattributes'),
-      this.destinationPath(this.options.generateInto, '.gitattributes')
+      this.destinationPath('.gitattributes')
     );
 
     this.fs.copy(
       this.templatePath('gitignore'),
-      this.destinationPath(this.options.generateInto, '.gitignore')
+      this.destinationPath('.gitignore')
     );
 
-    return originUrl(this.destinationPath(this.options.generateInto))
+    return originUrl(this.destinationPath())
       .then(function (url) {
         this.originUrl = url;
       }.bind(this), function () {
@@ -46,7 +39,7 @@ module.exports = generators.Base.extend({
   },
 
   writing: function () {
-    this.pkg = this.fs.readJSON(this.destinationPath(this.options.generateInto, 'package.json'), {});
+    this.pkg = this.fs.readJSON(this.destinationPath('package.json'), {});
 
     var repository = '';
     if (this.originUrl) {
@@ -61,12 +54,12 @@ module.exports = generators.Base.extend({
       this.pkg.repository.url = repository;
     }
 
-    this.fs.writeJSON(this.destinationPath(this.options.generateInto, 'package.json'), this.pkg);
+    this.fs.writeJSON(this.destinationPath('package.json'), this.pkg);
   },
 
   end: function () {
     this.spawnCommandSync('git', ['init'], {
-      cwd: this.destinationPath(this.options.generateInto)
+      cwd: this.destinationPath()
     });
 
     if (!this.originUrl) {
@@ -76,7 +69,7 @@ module.exports = generators.Base.extend({
         repoSSH = 'git@github.com:' + this.pkg.repository + '.git';
       }
       this.spawnCommandSync('git', ['remote', 'add', 'origin', repoSSH], {
-        cwd: this.destinationPath(this.options.generateInto)
+        cwd: this.destinationPath()
       });
     }
   }

--- a/generators/readme/index.js
+++ b/generators/readme/index.js
@@ -6,13 +6,6 @@ module.exports = generators.Base.extend({
   constructor: function () {
     generators.Base.apply(this, arguments);
 
-    this.option('generateInto', {
-      type: String,
-      required: false,
-      defaults: '',
-      desc: 'Relocate the location of the generated files.'
-    });
-
     this.option('name', {
       type: String,
       required: true,
@@ -57,10 +50,10 @@ module.exports = generators.Base.extend({
   },
 
   writing: function () {
-    var pkg = this.fs.readJSON(this.destinationPath(this.options.generateInto, 'package.json'), {});
+    var pkg = this.fs.readJSON(this.destinationPath('package.json'), {});
     this.fs.copyTpl(
       this.templatePath('README.md'),
-      this.destinationPath(this.options.generateInto, 'README.md'),
+      this.destinationPath('README.md'),
       {
         projectName: this.options.name,
         safeProjectName: _.camelCase(this.options.name),


### PR DESCRIPTION
### Prompt to create a new Directory for the app.
Issue : https://github.com/electrode-io/generator-electrode/issues/23

![final1](https://cloud.githubusercontent.com/assets/4782871/19909078/4b26a360-a043-11e6-8469-8ef904cc9e8e.png)

![o1](https://cloud.githubusercontent.com/assets/4782871/19909178/ac0cc326-a043-11e6-9e0a-c0de25d93a38.png)


### To maintain path consistency across sub generator 
#### Clean up of generateInto.
Certain sub generator are using `this.destinationPath()` to generate files  ex: https://github.com/jozefizso/generator-license/blob/master/app/index.js#L99.
While others use `this.destinationPath(this.options.generateInto, '.babelrc')`.