### PR TITLE
use WEBPACK_DEV_PORT environment variable

### DIFF
--- a/generators/webapp/templates/server/plugins/webapp/index.js
+++ b/generators/webapp/templates/server/plugins/webapp/index.js
@@ -141,7 +141,7 @@ const registerRoutes = (server, options, next) => {
     serverSideRendering: true,
     devServer: {
       host: "127.0.0.1",
-      port: "2992"
+      port: process.env.WEBPACK_DEV_PORT || "2992"
     },
     paths: {},
     stats: "dist/server/stats.json"


### PR DESCRIPTION
electrode-archetype-react-app use WEBPACK_DEV_PORT to customize the
webpack-dev-server port. This change allows the user to start the server with custom port