### PR TITLE
Import and consume browserHistory from react-router

### DIFF
--- a/generators/app/templates/client/app.jsx
+++ b/generators/app/templates/client/app.jsx
@@ -5,7 +5,7 @@
 import React from "react";
 import {render} from "react-dom";
 import {routes} from "./routes";
-import {Router} from "react-router";
+import {Router, browserHistory} from "react-router";
 import {createStore} from "redux";
 import {Provider} from "react-redux";
 import "./styles/base.css";
@@ -22,7 +22,7 @@ window.webappStart = () => {
   const store = createStore(rootReducer, initialState);
   render(
     <Provider store={store}>
-      <Router>{routes}</Router>
+      <Router history={browserHistory}>{routes}</Router>
     </Provider>,
     document.querySelector(".js-content")
   );


### PR DESCRIPTION
When generating a brand new Electrode project it fails in browser with an error of 
>Uncaught TypeError: Cannot read property 'getCurrentLocation' of undefined - Router.js:111

It seems that version 3.0.0 of React Router needs `browserHistory` explicitly imported for and consumed by the router component (I think this might mean that some error handling is missing somewhere in react-router's Router.js in the event you aren't passing it history, but that's a separate problem).

I tested the proposed changes with both 3.0.0 and 2.8.0 and projects generated out of the box seemed to work fine.